### PR TITLE
Refactor arguments creation in dbt-mode

### DIFF
--- a/dbt-mode.el
+++ b/dbt-mode.el
@@ -118,21 +118,29 @@
     (message (concat " " args))
     (dbt-mode-execute-command command)))
 
+(defun dbt-mode-create-arguments (args)
+  "Create a transient arguments structure with ARGS."
+  (let ((arguments-map
+         '(("lock" . ("l" "lock" "--lock"))
+           ("upgrade" . ("u" "upgrade" "--upgrade"))
+           ("full-refresh" . ("-f" "full-refresh" "--full-refresh"))
+           ("vars" . ("-v" "vars" "--vars="))
+           ("limit" . ("-l" "limit" "--limit")))))
+    (mapcar (lambda (arg) (cdr (assoc arg arguments-map))) args)))
+
 (transient-define-prefix dbt-mode-deps ()
   "A map for dbt deps arguments."
   ["Arguments"
-   [("l" "lock" "--lock")
-    ("u" "upgrade" "--upgrade")]]
-  ["dbt deps"
-   [("d" "Deps" dbt-mode--deps)]])
+   (dbt-mode-create-arguments '("lock" "upgrade"))
+   ["dbt deps"
+    [("d" "Deps" dbt-mode--deps)]]])
 
 (transient-define-prefix dbt-mode-run ()
   "A map for dbt run arguments."
   ["Arguments"
-   [("-f" "full-refresh" "--full-refresh")
-    ("-v" "vars" "--vars=")]]
-  ["dbt run"
-   [("r" "Run" dbt-mode--run)]])
+   (dbt-mode-create-arguments '("full-refresh" "vars"))
+   ["dbt run"
+    [("r" "Run" dbt-mode--run)]]])
 
 (transient-define-prefix dbt-mode-test ()
   "A map for dbt test arguments."
@@ -152,9 +160,9 @@
 (transient-define-prefix dbt-mode-show ()
   "A map for dbt show arguments."
   ["Arguments"
-   [("-l" "limit" "--limit")]]
-  ["dbt show"
-   [("s" "Show" dbt-mode--show)]])
+   (dbt-mode-create-arguments '("limit"))
+   ["dbt show"
+    [("s" "Show" dbt-mode--show)]]])
 
 (defun dbt-mode-clean ()
   "Clean the dbt project."


### PR DESCRIPTION
Isolate the prefixes creation in a separate function and call it in each command.

* Add a new function `dbt-mode-create-arguments` to handle arguments creation for `transient-define-prefix` definitions.
* Replace the arguments creation in each `transient-define-prefix` definition with a call to `dbt-mode-create-arguments`.
* Update the `transient-define-prefix` definitions to use `dbt-mode-create-arguments` to generate only the arguments.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/tuliolima/dbt-mode?shareId=30198679-d44a-4efd-91a2-69f815f5c3a9).